### PR TITLE
Export color and format variables in a global dictionary

### DIFF
--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -531,6 +531,24 @@ else
 endif
 
 "}}}
+" Export variables in a global dictionary"{{{
+" ---------------------------------------------------------------------
+
+let s:varnames = [
+    \ 'none','back','base03','base02','base01','base00','base0','base1','base2','base3',
+    \ 'green','yellow','orange','red','magenta','violet','blue','cyan',
+    \ 'bold','bldi','undr','undb','undi','uopt','curl','ital','stnd','revr','revb','revbb','revbbu']
+
+let g:solarized_vars = {}
+for item in s:varnames
+    for prefix in ['fg_','bg_','fmt_']
+        if exists('s:' . prefix . item)
+            exe "let g:solarized_vars['" . prefix . item . "']=s:" . prefix . item
+        endif
+    endfor
+endfor
+
+"}}}
 " Basic highlighting"{{{
 " ---------------------------------------------------------------------
 " note that link syntax to avoid duplicate configuration doesn't work with the


### PR DESCRIPTION
To be able to use the final values obtained by the solarized color scheme in user customizations, the local variables fg_xxx, bg_xxx and fmt_xxx are exported in a new global variable of type dictionary called g:solarized_vars. So they can be accessed easily following the syntax g:solarized_vars.fg_base0.
