### PR TITLE
improved SignColumn (showmarks gutter) and adde ShowMarks linkage to Diff colors

### DIFF
--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -686,10 +686,6 @@ hi! link PMenuSel DiffChange
 hi! link PMenuSbar DiffAdd 
 hi! link PMenuThumb DiffAdd
 
-" Brighter cursor and less confusing paren matching colors
-hi! link MatchParen IncSearch
-hi! link Cursor WildMenu
-
 "}}}
 " vim syntax highlighting "{{{
 " ---------------------------------------------------------------------

--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -654,7 +654,6 @@ exe "hi! DiffDelete"     .s:fmt_none   .s:fg_red    .s:bg_base02
 exe "hi! DiffText"       .s:fmt_none   .s:fg_blue   .s:bg_base02 .s:sp_blue
     endif
 endif
-exe "hi! SignColumn"     .s:fmt_none   .s:fg_base0
 exe "hi! Conceal"        .s:fmt_none   .s:fg_blue   .s:bg_none
 exe "hi! SpellBad"       .s:fmt_curl   .s:fg_none   .s:bg_none    .s:sp_red
 exe "hi! SpellCap"       .s:fmt_curl   .s:fg_none   .s:bg_none    .s:sp_violet
@@ -673,6 +672,11 @@ exe "hi! ColorColumn"    .s:fmt_none   .s:fg_none   .s:bg_base02
 exe "hi! Cursor"         .s:fmt_none   .s:fg_base03 .s:bg_base0
 hi! link lCursor Cursor
 exe "hi! MatchParen"     .s:fmt_bold   .s:fg_red    .s:bg_base01
+
+" ShowMarks support, better looking SignColumn
+hi! link SignColumn   LineNr
+hi! link ShowMarksHLl DiffAdd
+hi! link ShowMarksHLu DiffChange
 
 "}}}
 " vim syntax highlighting "{{{

--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -686,6 +686,10 @@ hi! link PMenuSel DiffChange
 hi! link PMenuSbar DiffAdd 
 hi! link PMenuThumb DiffAdd
 
+" Brighter cursor and less confusing paren matching colors
+hi! link MatchParen IncSearch
+hi! link Cursor WildMenu
+
 "}}}
 " vim syntax highlighting "{{{
 " ---------------------------------------------------------------------

--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -680,6 +680,12 @@ hi! link ShowMarksHLu DiffChange
 hi! link ShowMarksHLo DiffAdd
 hi! link ShowMarksHLm DiffChange
 
+" Better looking popup menu (for omnicomplete)
+hi! link PMenu DiffAdd 
+hi! link PMenuSel DiffChange
+hi! link PMenuSbar DiffAdd 
+hi! link PMenuThumb DiffAdd
+
 "}}}
 " vim syntax highlighting "{{{
 " ---------------------------------------------------------------------

--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -1127,3 +1127,48 @@ autocmd ColorScheme * if g:colors_name != "solarized" | silent! aunmenu Solarize
 "
 " vim:foldmethod=marker:foldlevel=0
 "}}}
+"
+"
+
+" Customizations by @skwp for better readability
+" If statements and def statements should look similar 
+" so you can see the flow 
+hi! link rubyDefine rubyControl
+
+" This is a better cursor
+hi! link Cursor VisualNOS
+
+" This is a bit nicer visual selection
+hi! link Visual DiffChange
+
+" Search is way too distracting in original Solarized
+hi! link Search DiffAdd
+
+" Colors to make LustyJuggler more usable
+" the Question color in LustyJuggler is mapped to
+" the currently selected buffer.
+hi! clear Question
+hi! Question guifg=yellow
+
+hi! link TagListFileName  Question
+
+" For jasmine.vim
+hi! link specFunctions rubyDefine
+hi! link specMatcher rubyConstant
+hi! link specSpys rubyConstant
+
+" Ruby, slightly better colors for solarized
+hi! link rubyStringDelimiter rubyConstant
+hi! link rubyInterpolationDelimiter rubyConstant
+hi! link rubySymbol Structure
+
+" For R and other languages that use Delimiters, we don't want them red
+hi! link Delimiter Identifier
+hi! link rDollar Identifier
+
+" For vimscript, don' tlike red..
+hi! link vimMapModKey Operator
+hi! link vimNotation Label
+
+" Better json highlighting
+hi! link htmlArg Label

--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -611,7 +611,7 @@ else
 endif
 exe "hi! StatusLine"     .s:fmt_none   .s:fg_base1  .s:bg_base02 .s:fmt_revbb
 exe "hi! StatusLineNC"   .s:fmt_none   .s:fg_base00 .s:bg_base02 .s:fmt_revbb
-exe "hi! Visual"         .s:fmt_none   .s:fg_base01 .s:bg_base03 .s:fmt_revbb
+exe "hi! Visual"         .s:fmt_none   .s:fg_none   .s:bg_base02
 exe "hi! Directory"      .s:fmt_none   .s:fg_blue   .s:bg_none
 exe "hi! ErrorMsg"       .s:fmt_revr   .s:fg_red    .s:bg_none
 exe "hi! IncSearch"      .s:fmt_stnd   .s:fg_orange .s:bg_none
@@ -1137,9 +1137,6 @@ hi! link rubyDefine rubyControl
 
 " This is a better cursor
 hi! link Cursor VisualNOS
-
-" This is a bit nicer visual selection
-hi! link Visual DiffChange
 
 " Search is way too distracting in original Solarized
 hi! link Search DiffAdd

--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -1172,3 +1172,7 @@ hi! link vimNotation Label
 
 " Better json highlighting
 hi! link htmlArg Label
+
+" Better indication of current buffer
+hi! link StatusLine DiffChange
+hi! link StatusLineNC DiffAdd

--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -677,6 +677,8 @@ exe "hi! MatchParen"     .s:fmt_bold   .s:fg_red    .s:bg_base01
 hi! link SignColumn   LineNr
 hi! link ShowMarksHLl DiffAdd
 hi! link ShowMarksHLu DiffChange
+hi! link ShowMarksHLo DiffAdd
+hi! link ShowMarksHLm DiffChange
 
 "}}}
 " vim syntax highlighting "{{{

--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -1176,3 +1176,5 @@ hi! link htmlArg Label
 " Better indication of current buffer
 hi! link StatusLine DiffChange
 hi! link StatusLineNC DiffAdd
+
+hi! VertSplit guifg=#002b36  guibg=#002b36


### PR DESCRIPTION
The SignColumn which appears to the left of the line number
column stood out in a very bad way because it was white.
I changed it to have the same appearance as the line number
column by using color linking. I also linked the ShowMarks
to DiffAdd and DiffChanged because those were nice already.
