### PR TITLE
[vim] fix g:solarized_termtrans

### DIFF
--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -372,6 +372,7 @@ if (has("gui_running") || g:solarized_termtrans == 0)
     let s:back        = s:base03
 else
     let s:back        = "NONE"
+    let s:base02      = "0"
 endif
 "}}}
 " Alternate light scheme "{{{


### PR DESCRIPTION
Change s:base02 to "0" for g:solarized_termtrans = 1. (256 colors is enabled)

For example, https://github.com/altercation/solarized/issues/138 is fixed by g:solarized_termtrans. Without the patch, background of numbers (:set number) and folders is brown.

![2012-12-18-161358_956x510_scrot](https://f.cloud.github.com/assets/960814/19309/a8b7a14c-490c-11e2-9cbb-2970e0cc5735.png)

I agree, that is dirty hack, but I don't know how to make better.

Thanks

P.S. I don't want use modified Xresources (URxvt, https://github.com/solarized/xresources), because it makes invalid bold colors. For instance, bold green is grey.
