### PR TITLE
Fix CursorLineNr in MacVim snapshot 66

### DIFF
--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -669,6 +669,7 @@ exe "hi! TabLineFill"    .s:fmt_undr   .s:fg_base0  .s:bg_base02  .s:sp_base0
 exe "hi! TabLineSel"     .s:fmt_undr   .s:fg_base01 .s:bg_base2   .s:sp_base0  .s:fmt_revbbu
 exe "hi! CursorColumn"   .s:fmt_none   .s:fg_none   .s:bg_base02
 exe "hi! CursorLine"     .s:fmt_uopt   .s:fg_none   .s:bg_base02  .s:sp_base1
+hi! link CursorLineNr LineNr
 exe "hi! ColorColumn"    .s:fmt_none   .s:fg_none   .s:bg_base02
 exe "hi! Cursor"         .s:fmt_none   .s:fg_base03 .s:bg_base0
 hi! link lCursor Cursor


### PR DESCRIPTION
In MacVim snapshot 66, CursorLineNr is "bright". This makes it like LineNr, much more pale.

(It was fine in MacVim snapshot 64 though.)
