### PR TITLE
Highlight definitions for vim-gitgutter

### DIFF
--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -654,7 +654,7 @@ exe "hi! DiffDelete"     .s:fmt_none   .s:fg_red    .s:bg_base02
 exe "hi! DiffText"       .s:fmt_none   .s:fg_blue   .s:bg_base02 .s:sp_blue
     endif
 endif
-exe "hi! SignColumn"     .s:fmt_none   .s:fg_base0  .s:bg_base02
+hi! link SignColumn LineNr
 exe "hi! Conceal"        .s:fmt_none   .s:fg_blue   .s:bg_none
 exe "hi! SpellBad"       .s:fmt_curl   .s:fg_none   .s:bg_none    .s:sp_red
 exe "hi! SpellCap"       .s:fmt_curl   .s:fg_none   .s:bg_none    .s:sp_violet

--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -654,7 +654,7 @@ exe "hi! DiffDelete"     .s:fmt_none   .s:fg_red    .s:bg_base02
 exe "hi! DiffText"       .s:fmt_none   .s:fg_blue   .s:bg_base02 .s:sp_blue
     endif
 endif
-exe "hi! SignColumn"     .s:fmt_none   .s:fg_base0
+exe "hi! SignColumn"     .s:fmt_none   .s:fg_base0  .s:bg_base02
 exe "hi! Conceal"        .s:fmt_none   .s:fg_blue   .s:bg_none
 exe "hi! SpellBad"       .s:fmt_curl   .s:fg_none   .s:bg_none    .s:sp_red
 exe "hi! SpellCap"       .s:fmt_curl   .s:fg_none   .s:bg_none    .s:sp_violet

--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -757,6 +757,11 @@ hi! link gitcommitUnmergedArrow  gitcommitUnmergedFile
 "exe "hi! gitcommitOverflow"
 "exe "hi! gitcommitBlank"
 " }}}
+" vim-gitgutter highlighting {{{
+exe "hi! lineAdded"         .s:fmt_bold .s:fg_green  .s:bg_base02
+exe "hi! lineModified"      .s:fmt_bold .s:fg_yellow .s:bg_base02
+exe "hi! lineRemoved"       .s:fmt_bold .s:fg_red    .s:bg_base02
+" }}}
 " html highlighting "{{{
 " ---------------------------------------------------------------------
 exe "hi! htmlTag"           .s:fmt_none .s:fg_base01 .s:bg_none


### PR DESCRIPTION
This change adds support for [vim-gitgutter](https://github.com/airblade/vim-gitgutter) highlight definitions. It also changes the SignColumn background to be the same as LineNr, as suggested in #26, for visual consistency when both gitgutter and line numbering are active.
