### PR TITLE
Invert sense of italic check

### DIFF
--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -425,10 +425,10 @@ else
     let s:u           = ",underline"
 endif
 
-if g:solarized_italic == 0 || s:terminal_italic == 0
-    let s:i           = ""
-else
+if g:solarized_italic == 1 || s:terminal_italic == 1
     let s:i           = ",italic"
+else
+    let s:i           = ""
 endif
 "}}}
 " Highlighting primitives"{{{


### PR DESCRIPTION
We're currently using a hard-coded list of terminals that are known to
either support or not support italics, and iTerm.app is currently in the
unsupported list.

The current HEAD of the iTerm 2 master branch, however, does add
optional support for italics:

  https://code.google.com/p/iterm2/issues/detail?id=391
  https://github.com/gnachman/iTerm2/commit/a2a7a8bfe050b03f2

This commit makes it possible for people running a sufficiently recent
build of iTerm 2 to opt in to using italics in Solarized by doing
`let g:solarized_italic=1` in their ~/.vimrc before the `:color
solarized` call. For everyone else, the behavior should be as it was
before.

Note that even if we move iTerm.app into the italic-supporting
whitelist, the ability to do an explicit opt-in in the ~/.vimrc is
especially useful in remote environments (eg. ssh'd into another host),
as the TERM_PROGRAM variable that Solarized is checking may not be
carried across into the remote environment, at least not with the
default ssh configuration for SendEnv and AcceptEnv.
