### PR TITLE
Correct code block in Advanced Configuration

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -132,7 +132,7 @@ Solarized will work out of the box with just the two lines specified above but
 does include several other options that can be set in your .vimrc file.
 
 Set these in your vimrc file prior to calling the colorscheme.
-"
+```
     option name               default     optional
     ------------------------------------------------
     g:solarized_termcolors=   16      |   256
@@ -144,6 +144,7 @@ Set these in your vimrc file prior to calling the colorscheme.
     g:solarized_contrast  =   "normal"|   "high" or "low"
     g:solarized_visibility=   "normal"|   "high" or "low"
     ------------------------------------------------
+```
 
 ### Option Details
 


### PR DESCRIPTION
Via the web, this section is [badly formatted](https://github.com/altercation/vim-colors-solarized#advanced-configuration).
