### PR TITLE
Change SignColumn to better support gitgutter and similar plugins

### DIFF
--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -654,7 +654,7 @@ exe "hi! DiffDelete"     .s:fmt_none   .s:fg_red    .s:bg_base02
 exe "hi! DiffText"       .s:fmt_none   .s:fg_blue   .s:bg_base02 .s:sp_blue
     endif
 endif
-exe "hi! SignColumn"     .s:fmt_none   .s:fg_base0
+exe "hi! SignColumn"     .s:fmt_none   .s:fg_blue   .s:bg_none
 exe "hi! Conceal"        .s:fmt_none   .s:fg_blue   .s:bg_none
 exe "hi! SpellBad"       .s:fmt_curl   .s:fg_none   .s:bg_none    .s:sp_red
 exe "hi! SpellCap"       .s:fmt_curl   .s:fg_none   .s:bg_none    .s:sp_violet


### PR DESCRIPTION
Change SignColumn to be same highlight as Conceal, allowing clear text to be rendered there, e.g. plus signs and tildas rendered by gitgutter
