### PR TITLE
make warning and error different

### DIFF
--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -589,7 +589,7 @@ exe "hi! Underlined"     .s:fmt_none   .s:fg_violet .s:bg_none
 exe "hi! Ignore"         .s:fmt_none   .s:fg_none   .s:bg_none
 "       *Ignore          left blank, hidden  |hl-Ignore|
 
-exe "hi! Error"          .s:fmt_bold   .s:fg_red    .s:bg_none
+exe "hi! Error"          .s:fmt_bold   .s:fg_none   .s:bg_red
 "       *Error           any erroneous construct
 
 exe "hi! Todo"           .s:fmt_bold   .s:fg_magenta.s:bg_none


### PR DESCRIPTION
The warning and error is the almost same before
![2014-03-14-174848_770x184_scrot](https://f.cloud.github.com/assets/1137238/2419455/de6c5ae4-ab5d-11e3-8de1-37766e8fdc7e.png)

After, it can see the error easily
![2014-03-14-175420_756x182_scrot](https://f.cloud.github.com/assets/1137238/2419498/a4fc96a6-ab5e-11e3-8a5d-791ba1dd7bea.png)
