### PR TITLE
Allow list of italic terms to be overridden

### DIFF
--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -672,6 +672,7 @@ exe "hi! TabLineFill"    .s:fmt_undr   .s:fg_base0  .s:bg_base02  .s:sp_base0
 exe "hi! TabLineSel"     .s:fmt_undr   .s:fg_base01 .s:bg_base2   .s:sp_base0  .s:fmt_revbbu
 exe "hi! CursorColumn"   .s:fmt_none   .s:fg_none   .s:bg_base02
 exe "hi! CursorLine"     .s:fmt_uopt   .s:fg_none   .s:bg_base02  .s:sp_base1
+exe "hi! CursorLineNr"   .s:fmt_bold   .s:fg_none   .s:bg_base02  .s:sp_base1
 exe "hi! ColorColumn"    .s:fmt_none   .s:fg_none   .s:bg_base02
 exe "hi! Cursor"         .s:fmt_none   .s:fg_base03 .s:bg_base0
 hi! link lCursor Cursor

--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -139,6 +139,9 @@ let s:terms_italic=[
             \"rxvt",
             \"gnome-terminal"
             \]
+if exists("g:solarized_terms_italic")
+  let s:terms_italic=g:solarized_terms_italic
+endif
 " For reference only, terminals are known to be incomptible.
 " Terminals that are in neither list need to be tested.
 let s:terms_noitalic=[

--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -657,7 +657,7 @@ exe "hi! DiffDelete"     .s:fmt_none   .s:fg_red    .s:bg_base02
 exe "hi! DiffText"       .s:fmt_none   .s:fg_blue   .s:bg_base02 .s:sp_blue
     endif
 endif
-exe "hi! SignColumn"     .s:fmt_none   .s:fg_base0
+exe "hi! SignColumn"     .s:fmt_none   .s:fg_base0  .s:bg_base02
 exe "hi! Conceal"        .s:fmt_none   .s:fg_blue   .s:bg_none
 exe "hi! SpellBad"       .s:fmt_curl   .s:fg_none   .s:bg_none    .s:sp_red
 exe "hi! SpellCap"       .s:fmt_curl   .s:fg_none   .s:bg_none    .s:sp_violet


### PR DESCRIPTION
This is a another way of of improving italic support (vs #65). In this case, we're allowing users to override the set of terminals known to support italic.
