### PR TITLE
[vim] add st to list of terminals supporting italics

### DIFF
--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -137,7 +137,8 @@
 " Terminals that support italics
 let s:terms_italic=[
             \"rxvt",
-            \"gnome-terminal"
+            \"gnome-terminal",
+            \"st"
             \]
 " For reference only, terminals are known to be incomptible.
 " Terminals that are in neither list need to be tested.

--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -151,7 +151,7 @@ if has("gui_running")
 else
     let s:terminal_italic=0 " terminals will be guilty until proven compatible
     for term in s:terms_italic
-        if $TERM_PROGRAM =~ term
+        if $TERM =~ term
             let s:terminal_italic=1
         endif
     endfor

--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -138,7 +138,8 @@
 let s:terms_italic=[
             \"rxvt",
             \"gnome-terminal",
-            \"st"
+            \"st",
+            \"screen-256color-italic"
             \]
 " For reference only, terminals are known to be incomptible.
 " Terminals that are in neither list need to be tested.


### PR DESCRIPTION
simple terminal from suckless (http://st.suckless.org/) supports
italics.
