### PR TITLE
[vim] wildmenu highlight colors inverted for enhanced visibility

### DIFF
--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -628,8 +628,8 @@ endif
 exe "hi! Title"          .s:fmt_bold   .s:fg_orange .s:bg_none
 exe "hi! VisualNOS"      .s:fmt_stnd   .s:fg_none   .s:bg_base02 .s:fmt_revbb
 exe "hi! WarningMsg"     .s:fmt_bold   .s:fg_red    .s:bg_none
-exe "hi! WildMenu"       .s:fmt_none   .s:fg_base2  .s:bg_base02 .s:fmt_revbb
-exe "hi! Folded"         .s:fmt_undb   .s:fg_base0  .s:bg_base02  .s:sp_base03
+exe "hi! WildMenu"       .s:fmt_none   .s:fg_base02 .s:bg_base2  .s:fmt_revbb
+exe "hi! Folded"         .s:fmt_undb   .s:fg_base0  .s:bg_base02 .s:sp_base03
 exe "hi! FoldColumn"     .s:fmt_none   .s:fg_base0  .s:bg_base02
 if      (g:solarized_diffmode=="high")
 exe "hi! DiffAdd"        .s:fmt_revr   .s:fg_green  .s:bg_none


### PR DESCRIPTION
In vim (terminal and GUI) the highlighted wildmenu item was almost invisible in low cost displays. By inverting the assigned colors it becomes clear which option is highlighted in every display.
