### PR TITLE
fix ctermfg for popup menu

### DIFF
--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -660,7 +660,7 @@ exe "hi! SpellBad"       .s:fmt_curl   .s:fg_none   .s:bg_none    .s:sp_red
 exe "hi! SpellCap"       .s:fmt_curl   .s:fg_none   .s:bg_none    .s:sp_violet
 exe "hi! SpellRare"      .s:fmt_curl   .s:fg_none   .s:bg_none    .s:sp_cyan
 exe "hi! SpellLocal"     .s:fmt_curl   .s:fg_none   .s:bg_none    .s:sp_yellow
-exe "hi! Pmenu"          .s:fmt_none   .s:fg_base0  .s:bg_base02  .s:fmt_revbb
+exe "hi! Pmenu"          .s:fmt_none   .s:fg_base02 .s:bg_base02  .s:fmt_revbb
 exe "hi! PmenuSel"       .s:fmt_none   .s:fg_base01 .s:bg_base2   .s:fmt_revbb
 exe "hi! PmenuSbar"      .s:fmt_none   .s:fg_base2  .s:bg_base0   .s:fmt_revbb
 exe "hi! PmenuThumb"     .s:fmt_none   .s:fg_base0  .s:bg_base03  .s:fmt_revbb


### PR DESCRIPTION
The existing value for Pmenu made the selection indistinguishable from the rest of the menu:

![screenshot 2016-03-31 16 30 37](https://cloud.githubusercontent.com/assets/845857/14193916/fbea42ea-f75d-11e5-99cf-cea33d0d77f9.png)

This fixes it:

![screenshot 2016-03-31 16 30 52](https://cloud.githubusercontent.com/assets/845857/14193928/10df929a-f75e-11e5-8cb5-a12deb7aa704.png)
