### PR TITLE
Add support for guicolors option

### DIFF
--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -240,7 +240,7 @@ let colors_name = "solarized"
 " leave the hex values out entirely in that case and include only cterm colors)
 " We also check to see if user has set solarized (force use of the
 " neutral gray monotone palette component)
-if (has("gui_running") && g:solarized_degrade == 0)
+if ((has("gui_running") || &guicolors) && g:solarized_degrade == 0)
     let s:vmode       = "gui"
     let s:base03      = "#002b36"
     let s:base02      = "#073642"


### PR DESCRIPTION
Enable true colors when option guicolors is set.

See https://github.com/vim/vim/commit/8a633e3427b47286869aa4b96f2bfc1fe65b25cd for more information.
