### PR TITLE
Fixes typo in README.mkd

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -118,7 +118,7 @@ If you do use the custom terminal colors, solarized.vim should work out of the
 box for you. If you are using a terminal emulator that supports 256 colors and 
 don't want to use the custom Solarized terminal colors, you will need to use 
 the degraded 256 colorscheme. To do so, simply add the following line *before* 
-the `colorschem solarized` line:
+the `colorscheme solarized` line:
 
     let g:solarized_termcolors=256
 


### PR DESCRIPTION
Fixed typo from `colorschem solarized` to `colorscheme solarized`.