### PR TITLE
add support for NeoVim’s termguicolors

### DIFF
--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -240,7 +240,7 @@ let colors_name = "solarized"
 " leave the hex values out entirely in that case and include only cterm colors)
 " We also check to see if user has set solarized (force use of the
 " neutral gray monotone palette component)
-if (has("gui_running") && g:solarized_degrade == 0)
+if ((has("gui_running") || has("termguicolors")) && g:solarized_degrade == 0)
     let s:vmode       = "gui"
     let s:base03      = "#002b36"
     let s:base02      = "#073642"


### PR DESCRIPTION
Terminal users have to sacrifice secondary/bold colors everywhere in terminal output for the sake of proper coloring in Vim. But there are many terminals, including Xterm who support truecolor. NeoVim supports truecolor as well, and after this change adding `set termguicolors` in `~/.config/nvim/init.vim` selectively allows for using colors outside of predefined .Xdefaults.