### PR TITLE
Update README.mkd (git:// to https://)

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -65,7 +65,7 @@ Installation
     a. **Clone:** 
 
             $ cd ~/.vim/bundle
-            $ git clone git://github.com/altercation/vim-colors-solarized.git
+            $ git clone https://github.com/altercation/vim-colors-solarized.git
 
     b. **Move:**
 


### PR DESCRIPTION
Original line errors out.
`git clone git://github.com/altercation/vim-colors-solarized.git`
Cloning into 'vim-colors-solarized'...
fatal: unable to connect to github.com:
github.com[0: 20.248.137.48]: errno=Operation timed out

Proposed line works as expected.
`git clone https://github.com/altercation/vim-colors-solarized.git`
Cloning into 'vim-colors-solarized'...
remote: Enumerating objects: 336, done.
remote: Total 336 (delta 0), reused 0 (delta 0), pack-reused 336
Receiving objects: 100% (336/336), 151.84 KiB | 765.00 KiB/s, done.
Resolving deltas: 100% (90/90), done.
